### PR TITLE
Return message if a pkg can't be found

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -27,7 +27,8 @@ autoinst <- function() {
           cat(multicol(paste0(sprintf(paste0("%", width_nums, "s"), nums), "| ", gh_pkgs$pkg_location[matches])), sep = "")
           get_answer(sprintf("Which package would you like to install? (1-%d, N): ", length(matches)), c(as.character(seq(1, length(matches))), "N"), "N")
         } else {
-          "N"
+          message("Unable to install ", pkg)
+          return()
         }
       if (i != "N") {
         devtools::install_github(gh_pkgs$pkg_location[matches[as.integer(i)]])


### PR DESCRIPTION
Currently if a package can't be found, the message is misleading, e.g.

```
R> library("ggplot3")
Error in library("ggplot3") : there is no package called 'ggplot3'
Can now rerun
library("ggplot3")
```
This PR gives a more better message

```
R> library("ggplot3")
Error in library("ggplot3") : there is no package called 'ggplot3'
Unable to install ggplot3
````